### PR TITLE
kaminari を使ったページング処理の追加

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,9 @@
+---
+glob: "**/*.{html,text,js}{+*,}.erb"
+exclude:
+  - '**/vendor/**/*'
+  - '**/node_modules/**/*'
+linters:
+  # generatorが自動生成したerbがこの規則に従っていないことが多いので、検証対象から外す
+  SelfClosingTag:
+    enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,4 @@ gem 'net-pop'
 gem 'net-smtp'
 
 gem 'carrierwave'
+gem 'kaminari'

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'erb_lint', require: false
   gem 'i18n_generators'
   gem 'listen', '~> 3.3'
   gem 'rack-mini-profiler', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,18 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -294,6 +306,7 @@ DEPENDENCIES
   erb_lint
   i18n_generators
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.3)
   net-imap
   net-pop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,14 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    better_html (1.0.16)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     bindex (0.8.1)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
@@ -89,10 +97,19 @@ GEM
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     digest (3.1.0)
+    erb_lint (0.1.3)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
     erubi (1.10.0)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    html_tokenizer (0.0.7)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     i18n_generators (2.2.2)
@@ -224,6 +241,7 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
+    smart_properties (1.17.0)
     spring (4.0.0)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
@@ -273,6 +291,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   carrierwave
+  erb_lint
   i18n_generators
   jbuilder (~> 2.7)
   listen (~> 3.3)

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -6,7 +6,7 @@ class BooksController < ApplicationController
   # GET /books
   # GET /books.json
   def index
-    @books = Book.all
+    @books = Book.page(params[:page]).per(3)
   end
 
   # GET /books/1

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -6,7 +6,7 @@ class BooksController < ApplicationController
   # GET /books
   # GET /books.json
   def index
-    @books = Book.page(params[:page]).per(3)
+    @books = Book.page(params[:page]).per(3).order(:id)
   end
 
   # GET /books/1

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -6,7 +6,7 @@ class BooksController < ApplicationController
   # GET /books
   # GET /books.json
   def index
-    @books = Book.page(params[:page]).per(3).order(:id)
+    @books = Book.page(params[:page]).order(:id)
   end
 
   # GET /books/1

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -6,7 +6,7 @@ class BooksController < ApplicationController
   # GET /books
   # GET /books.json
   def index
-    @books = Book.page(params[:page]).order(:id)
+    @books = Book.order(:id).page(params[:page])
   end
 
   # GET /books/1

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,4 +2,5 @@
 
 class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
+  paginates_per 3
 end

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -15,19 +15,22 @@
 
   <tbody>
     <% @books.each do |book| %>
-      <tr>
-        <td><%= book.title %></td>
-        <td><%= book.memo %></td>
-        <td><%= book.author %></td>
-        <td><%= book.picture %></td>
-        <td><%= link_to t('views.common.show'), book %></td>
-        <td><%= link_to t('views.common.edit'), edit_book_path(book) %></td>
-        <td><%= link_to t('views.common.destroy'), book, method: :delete, data: { confirm: t('views.common.delete_confirm') } %></td>
-      </tr>
+    <tr>
+      <td><%= book.title %></td>
+      <td><%= book.memo %></td>
+      <td><%= book.author %></td>
+      <td><%= book.picture %></td>
+      <td><%= link_to t('views.common.show'), book %></td>
+      <td><%= link_to t('views.common.edit'), edit_book_path(book) %></td>
+      <td>
+        <%= link_to t('views.common.destroy'), book, method: :delete, data: { confirm: t('views.common.delete_confirm') } %>
+      </td>
+    </tr>
     <% end %>
   </tbody>
 </table>
 
 <br>
 
+<%= paginate @books %>
 <%= link_to t('views.common.new'), new_book_path %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,6 +223,12 @@ en:
       delete_confirm: "Are you sure?"
       title_new: "New %{name}"
       title_edit: "Editing %{name}"
+    pagination:
+      first: "&laquo; First"
+      last: "Last &raquo;"
+      previous: "&lsaquo; Prev"
+      next: "Next &rsaquo;"
+      truncate: "&hellip;"
   controllers:
     common:
       notice_create: "%{name} was successfully created."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -215,6 +215,12 @@ ja:
       delete_confirm: よろしいですか？
       title_new: "%{name}の新規作成"
       title_edit: "%{name}の編集"
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "&hellip;"
   controllers:
     common:
       notice_create: "%{name}が作成されました。"


### PR DESCRIPTION
## やったこと

kaminari gemを使ったページング処理の追加。

## できるようになること

* 本の一覧ページのページネーションのリンクから任意のページへアクセスできる。
* ページネーションの表示を英語/日本語で切り替えることができる。

## 動作確認

* 手動でページネーションの動作を確認。
* rubocop、erblintが全てパスすることを確認。

## 質問

ページネーションを日本語化するために`config/locals/ja.yml` と`config/locales/en.yml` に翻訳情報を追加しましたが、ページネーションのデフォルト表示が既に英語なので`config/locales/en.yml` への翻訳情報の追加が不要な気がしました。
不要な場合は今後は必要な翻訳情報のみ追加したいと考えています。
逆に必要な場合は今後の為に理由を教えていただきたいです！